### PR TITLE
Add git-switch to switch between branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Add this folder to your path, so `git` can pick up the scripts.
 
 `git start [feature]`
 
+### Switch
+
+**Switches between feature branches.**
+
+`git switch [feature]`
+
+If the feature branch named `$USERNAME/feature` isn't found, the command tries
+out the name verbatim. This means it can also be used with non-feature branches
+(such as `master`).
 
 ### Sync
 

--- a/git-start
+++ b/git-start
@@ -31,9 +31,7 @@ try:
 except git.exc.InvalidGitRepositoryError:
     util.fatal('git start must be run from within a valid git repository.')
 
-username = util.get_github_creds()['username']
-new_branch_name = '%s/%s' % (username, sys.argv[1])
-
+new_branch_name = util.get_branch_name(sys.argv[1])
 initial_branch = repo.active_branch
 
 util.fatal_if_dirty(repo)

--- a/git-switch
+++ b/git-switch
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+# git-switch
+#
+# Switches between feature branches.
+#
+# Usage:
+#     git switch banana
+#     git switch master
+#
+# Is equivalent to calling:
+#     git checkout <prefix>/banana
+#     git checkout master
+#
+# If the prefixed version of the branch wasn't found, it also
+# tries the name verbatim.
+
+import sys
+import os
+import git
+import util
+
+if len(sys.argv) < 2:
+  util.fatal('Incorrect usage, missing branch name. Use: git switch [feature]')
+
+try:
+    repo = git.Repo(os.getcwd(), search_parent_directories=True)
+except git.exc.InvalidGitRepositoryError:
+    util.fatal('git start must be run from within a valid git repository.')
+
+util.fatal_if_dirty(repo)
+
+# Try prefixed name first, then verbatim.
+branch_names = (util.get_branch_name(sys.argv[1]), sys.argv[1])
+for name in branch_names:
+  if name in repo.heads:
+    repo.heads[name].checkout()
+    util.success('Switched to %s' % name)
+    exit(0)
+
+util.fatal('Branch not found. Tried: %s' % ', '.join(branch_names))

--- a/util.py
+++ b/util.py
@@ -1,4 +1,3 @@
-
 import json
 import getpass
 import os.path
@@ -59,6 +58,15 @@ def update_master(repo, initial_branch):
 		c = prompt_y_n('Continue anyway?')
 		if not c:
 			exit(1)
+
+
+def get_branch_name(name):
+	"""
+	Returns the full, prefixed branch name.
+	"""
+	username = get_github_creds()['username']
+	return '%s/%s' % (username, name)
+
 
 def get_auth_filename():
 	"""


### PR DESCRIPTION
This allows people to switch between branches without typing their prefix. For example,

```
☭ git branch
* master
  valueof/with-prefix
  without-prefix

☭ git switch with-prefix
> Checking for pending changes
> Switched to valueof/with-prefix

☭ git switch without-prefix
> Checking for pending changes
> Switched to without-prefix

☭ git switch master
> Checking for pending changes
> Switched to master

☭ git switch invalid-name
> Checking for pending changes
Branch not found. Tried: valueof/invalid-name, invalid-name
```

@dpup 