### PR TITLE
git-pull-request: improve repo name matching to allow repos with dots in the name

### DIFF
--- a/git-pull-request
+++ b/git-pull-request
@@ -37,7 +37,13 @@ remote_ref = '%s/%s' % (remote_origin, remote_branch)
 
 repo_root = repo.git.rev_parse("--show-toplevel")
 repo_url = list(repo.remotes.origin.urls)[0]
-m = re.search(':([^.]+)(\.|$)', repo_url)
+
+# Important things to match:
+# git@github.com:user/repo
+# git@github.com:user/repo.with.dot
+# git@github.com:user/repo.git
+# git@github.com:user/repo.with.dot.git
+m = re.search(':(.+?)(?:\.git)?$', repo_url)
 if m:
   repo_path = m.group(1)
 else:


### PR DESCRIPTION
Hello @dpup,

Please review the following commits I made in branch nicks/repomatch:

78551fdfb29d4790ea8080ca2fed7610a8960881 (2019-01-24 19:03:31 -0500)
git-pull-request: improve repo name matching to allow repos with dots in the name

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics