### PR TITLE
git-pull-request: catch ConfigParser errors in a more robust way

### DIFF
--- a/git-pull-request
+++ b/git-pull-request
@@ -36,6 +36,12 @@ def get_reviewer_aliases(repo):
     kv_pairs = reader.items("gitworkflow \"alias\"")
   except cp.NoSectionError:
     return {}
+  except Exception as e:
+    # Catch NoSectionError in a way that's compatible
+    # across python versions.
+    if 'NoSectionError' in str(type(e)):
+      return {}
+    raise e
 
   return {str(pair[0]): str(pair[1]) for pair in kv_pairs}
 


### PR DESCRIPTION
Hello @dpup,

Please review the following commits I made in branch nicks/configparser:

eb00c0ef353d956656d0ab0261161197b5c779cb (2020-01-23 14:11:05 -0500)
git-pull-request: catch ConfigParser errors in a more robust way

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics