### PR TITLE
Use remove_prefix instead of lstrip

### DIFF
--- a/git-cleanup
+++ b/git-cleanup
@@ -30,10 +30,14 @@ for line in branches.splitlines():
     repo.git.branch('-d', branch)
     local_count += 1
 
+def trim_prefix(text, prefix):
+  if text.startswith(prefix):
+    return text[len(prefix):]
+
 remote_count = 0
 branches = repo.git.branch('-r', '--merged', main)
 for line in branches.splitlines():
-  branch = line.strip().lstrip('origin/')
+  branch = trim_prefix(line.strip(), 'origin/')
   if main not in branch:
     util.info('Removing origin/%s' % branch)
     repo.git.push('--delete', 'origin', branch)


### PR DESCRIPTION
Hello @dpup,

Please review the following commits I made in branch nicks/lstrip:

3ccb5b3511f85ec633bed34820103c7d862298d2 (2020-11-05 09:59:30 -0500)
Use remove_prefix instead of lstrip
lstrip() removes all characters in the set, which is not quite what we want here

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics